### PR TITLE
Remove now unused rexpr_codes

### DIFF
--- a/prolog/real.pl
+++ b/prolog/real.pl
@@ -1205,9 +1205,6 @@ r_send( R ) :-
      debug( real, 'Sending to R: ~s', [Rcodes] ),
      send_r_command( Rcodes ).
 
-rexpr_codes( Rterm, RTmps, Rcodes ) :-
-     rexpr_codes( Rterm, RTmps, Rcodes, [] ).
-
 assignment(PlDataIn, Rvar) :-
      % atom( Rvar ),
      rvar_identifier( Rvar, Rvar, _ ),
@@ -1278,15 +1275,11 @@ rvar_identifier_1( A@B, Rv, C ) :-
      atomic_list_concat( [Aatom,'@',Batom], C ).
 rvar_identifier_1( []([[B]],A), Rv, C ) :-
      rvar_identifier_1( A, Rv, Aatom ),
-     % rexpr_codes(B, [], BCs, [] ),
      rexpr( B, [], Batom ),
-     % atom_codes( Batom, BCs ),
      atomic_list_concat( [Aatom,'[[',Batom,']]'], C ).
 rvar_identifier_1( A^[[B]], Rv, C ) :-
      rvar_identifier_1( A, Rv, Aatom ),
-     % rexpr_codes(B, [], BCs, [] ),
      rexpr( B, [], Batom ),
-     % atom_codes( Batom, BCs ),
      atomic_list_concat( [Aatom,'[[',Batom,']]'], C ).
 rvar_identifier_1( [](B,A), A, C ) :-
      rindices( B, Batom ),
@@ -1298,7 +1291,7 @@ rvar_identifier_1( A^B, A, C ) :-
 	rindices( B, Batom ),
      atom_concat( A, Batom, C ).
 
-/** rexpr_codes(V,_,_).
+/** rexpr(V,_,_).
 
      Generate (or parse) an R expression as codes from/to a Prolog term.
 */


### PR DESCRIPTION
I think this is now replaced by rexpr. Removing this to avoid undefined predicate warning when using real.